### PR TITLE
use flatDir for dependency jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ logs
 .classpath
 .settings
 bin
+libs

--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ Polychat is a messaging protocol to exchange chat messages between Discord and m
 
 You should now have communication between your Polychat server and client.
 
+## Compiling from source
+<details><summary>Click me</summary>
+
+# Compiling
+
+To compile from source, you must first compile the ``client-base``, ``message-libary``,
+``common``, and ``network-library`` subprojects.
+
+NOTE: These require java 8 to compile, while some clients like 1.17 will need other versions of java.
+
+This can be done by going to their respective folders and running ``./gradlew build``.
+
+Then you copy the jars to `/client/<version>/libs` and finally run ``./gradlew build`` in the client 
+version you want to compile.
+
+</details>
+
+
 ## Commands
 ### General commands
 * `!help`: Direct messages the user who executed the command with a list of all commands

--- a/client/bukkit-1.7.10/build.gradle
+++ b/client/bukkit-1.7.10/build.gradle
@@ -11,6 +11,9 @@ repositories {
     maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
     mavenCentral()
+    flatDir {
+        dirs 'libs'
+    }
 }
 
 configurations {
@@ -20,10 +23,10 @@ configurations {
 
 dependencies {
     compileOnly files('./bukkit-1.4.7.jar')
-    embed files("../../core/message-library/build/libs/message-library-${version}.jar")
-    embed files("../../core/network-library/build/libs/network-library-${version}.jar")
-    embed files("../../core/common/build/libs/common-${version}.jar")
-    embed files("../client-base/build/libs/client-base-${version}.jar")
+    embed name: "message-library-${version}"
+    embed name: "network-library-${version}"
+    embed name: "common-${version}"
+    embed name: "client-base-${version}"
     embed "com.google.protobuf:protobuf-java:3.13.+"
     embed "org.yaml:snakeyaml:1.+"
 }

--- a/client/client-base/build.gradle
+++ b/client/client-base/build.gradle
@@ -6,12 +6,15 @@ version = "2.0.2"
 
 repositories {
     mavenCentral()
+    flatDir {
+        dirs 'libs'
+    }
 }
 
 dependencies {
-    compile files("../../core/message-library/build/libs/message-library-${version}.jar")
-    compile files("../../core/network-library/build/libs/network-library-${version}.jar")
-    compile files("../../core/common/build/libs/common-${version}.jar")
+    compile name: "message-library-${version}"
+    compile name: "network-library-${version}"
+    compile name: "common-${version}"
     compile "com.google.protobuf:protobuf-java:3.13.0"
     compile "org.yaml:snakeyaml:1.+"
 }

--- a/client/fabric-1.17/build.gradle
+++ b/client/fabric-1.17/build.gradle
@@ -22,6 +22,9 @@ group = project.maven_group
 repositories {
     jcenter()
     mavenCentral()
+    flatDir {
+        dirs 'libs'
+    }
 }
 
 dependencies {
@@ -33,18 +36,18 @@ dependencies {
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modImplementation(files("../../core/message-library/build/libs/message-library-${version}.jar"))
-    modImplementation(files("../../core/network-library/build/libs/network-library-${version}.jar"))
-    modImplementation(files("../../core/common/build/libs/common-${version}.jar"))
-    modImplementation(files("../client-base/build/libs/client-base-${version}.jar"))
+    modImplementation(name: "message-library-${version}")
+    modImplementation(name: "network-library-${version}")
+    modImplementation(name: "common-${version}")
+    modImplementation(name: "client-base-${version}")
     modImplementation("com.google.protobuf:protobuf-java:3.13.0")
     modImplementation("org.yaml:snakeyaml:1.+")
 
     // shadow the above.
-    shadow(files("../../core/message-library/build/libs/message-library-${version}.jar"))
-    shadow(files("../../core/network-library/build/libs/network-library-${version}.jar"))
-    shadow(files("../../core/common/build/libs/common-${version}.jar"))
-    shadow(files("../client-base/build/libs/client-base-${version}.jar"))
+    shadow(name: "message-library-${version}")
+    shadow(name: "network-library-${version}")
+    shadow(name: "common-${version}")
+    shadow(name: "../client-base/build/libs/client-base-${version}.jar")
     shadow("com.google.protobuf:protobuf-java:3.13.0")
     shadow("org.yaml:snakeyaml:1.+")
 

--- a/client/forge-1.12.2/build.gradle
+++ b/client/forge-1.12.2/build.gradle
@@ -38,6 +38,12 @@ configurations {
     compile.extendsFrom(embed)
 }
 
+respositories {
+    flatDir {
+        dirs 'libs'
+    }
+}
+
 dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
@@ -45,10 +51,10 @@ dependencies {
     minecraft 'net.minecraftforge:forge:1.12.2-14.23.5.2854'
 
     // embed these into the jar
-    embed files("../../core/message-library/build/libs/message-library-${version}.jar")
-    embed files("../../core/network-library/build/libs/network-library-${version}.jar")
-    embed files("../../core/common/build/libs/common-${version}.jar")
-    embed files("../client-base/build/libs/client-base-${version}.jar")
+    embed files(name: "message-library-${version}")
+    embed files(name: "network-library-${version}")
+    embed files(name: "common-${version}")
+    embed files(name: "client-base-${version}")
     embed "com.google.protobuf:protobuf-java:3.13.0"
     embed "org.yaml:snakeyaml:1.+"
 }

--- a/client/forge-1.16/build.gradle
+++ b/client/forge-1.16/build.gradle
@@ -25,15 +25,21 @@ minecraft {
     mappings channel: 'snapshot', version: '20201028-1.16.3'
 }
 
+respositories {
+    flatDir {
+        dirs 'libs'
+    }
+}
+
 dependencies {
     // IMPORTANT NOTE WHEN UPGRADING FORGE VERSION:
     // RUN THE jar COMMAND BEFORE FIRST BUILD AFTER UPGRADE
     // OTHERWISE YOU WILL GET A BUNCH OF SCARY ERRORS
     minecraft 'net.minecraftforge:forge:1.16.4-35.0.18'
-    compile files("../../core/message-library/build/libs/message-library-${version}.jar")
-    compile files("../../core/network-library/build/libs/network-library-${version}.jar")
-    compile files("../../core/common/build/libs/common-${version}.jar")
-    compile files("../client-base/build/libs/client-base-${version}.jar")
+    compile name: "message-library-${version}"
+    compile name: "network-library-${version}"
+    compile name: "common-${version}"
+    compile name: "client-base-${version}"
     compile "com.google.protobuf:protobuf-java:3.13.0"
     compile "org.yaml:snakeyaml:1.+"
 }
@@ -56,9 +62,9 @@ jar {
 shadowJar {
     classifier = ""
     dependencies {
-        include(dependency(files("../../core/message-library/build/libs/message-library.jar")))
-        include(dependency(files("../../core/network-library/build/libs/network-library.jar")))
-        include(dependency(files("../../core/common/build/libs/common.jar")))
+        include(dependency(name: "message-library"))
+        include(dependency(name: "network-library"))
+        include(dependency(name: "common"))
         include(dependency("com.google.protobuf:protobuf-java:3.13.0"))
         include(dependency("org.yaml:snakeyaml:1.+"))
     }

--- a/client/forge-1.18/build.gradle
+++ b/client/forge-1.18/build.gradle
@@ -6,6 +6,9 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        flatDir {
+            dirs 'lib'
+        }
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
@@ -111,19 +114,25 @@ configurations {
     shade
 }
 
+repositories {
+    flatDir {
+        dirs 'libs'
+    }
+}
+
 dependencies {
     minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
-    compileOnly(files("../../core/message-library/build/libs/message-library-${version}.jar"))
-    compileOnly(files("../../core/network-library/build/libs/network-library-${version}.jar"))
-    compileOnly(files("../../core/common/build/libs/common-${version}.jar"))
-    compileOnly(files("../client-base/build/libs/client-base-${version}.jar"))
+    compileOnly(name: "message-library-${version}")
+    compileOnly(name: "network-library-${version}" )
+    compileOnly(name: "common-${version}")
+    compileOnly(name: "client-base-${version}")
     compileOnly("com.google.protobuf:protobuf-java:3.13.0")
     compileOnly("org.yaml:snakeyaml:1.+")
 
-    shade(files("../../core/message-library/build/libs/message-library-${version}.jar"))
-    shade(files("../../core/network-library/build/libs/network-library-${version}.jar"))
-    shade(files("../../core/common/build/libs/common-${version}.jar"))
-    shade(files("../client-base/build/libs/client-base-${version}.jar"))
+    shade(name: "message-library-${version}")
+    shade(name: "network-library-${version}")
+    shade(name: "common-${version}")
+    shade(name: "client-base-${version}")
     shade("com.google.protobuf:protobuf-java:3.13.0")
     shade("org.yaml:snakeyaml:1.+")
 }


### PR DESCRIPTION
This provides multiple benefits, most notably not having dependencies rely on relative pathing to the build dir of projects.