### PR TITLE
Allow more versatile implementations of Polychat clients

### DIFF
--- a/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/PolychatClient.java
+++ b/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/PolychatClient.java
@@ -22,12 +22,12 @@ import java.util.List;
 public class PolychatClient {
 
     private final ClientApiBase clientApi;
-    private Client client;
-    private PolychatProtobufMessageDispatcher polychatProtobufMessageDispatcher;
-    private YamlConfig config;
-    private String serverId;
-    private ClientCallbacks clientCallbacks;
-    private MuteStorage muteStorage;
+    private final Client client;
+    private final PolychatProtobufMessageDispatcher polychatProtobufMessageDispatcher;
+    private final YamlConfig config;
+    private final String serverId;
+    private final ClientCallbacks clientCallbacks;
+    private final MuteStorage muteStorage;
     private long lastUpdate = 0;
     private static final HashMap<Integer, Integer> colorHashMap = new HashMap<Integer, Integer>() {{
         put(0, 0x000000);
@@ -54,19 +54,13 @@ public class PolychatClient {
      * @param clientImpl the implementation of the client protocol
      */
     public PolychatClient(ClientApiBase clientImpl) {
-        clientApi = clientImpl;
-        initialize();
+        this(clientImpl, null);
     }
 
     public PolychatClient(ClientApiBase clientImpl, YamlConfig customConfig) {
         clientApi = clientImpl;
-        config = customConfig;
-        initialize();
-    }
-
-    private void initialize() {
+        config = customConfig != null ? customConfig : getConfig();
         clientCallbacks = new ClientCallbacks(this);
-        config = getConfig();
         client = new Client(config.getOrDefault("server.address", "localhost"),
                 config.getOrDefault("server.port", 5005), config.getOrDefault("server.buffersize", 32768));
         polychatProtobufMessageDispatcher = new PolychatProtobufMessageDispatcher();

--- a/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/handlers/CommandMessageHandler.java
+++ b/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/handlers/CommandMessageHandler.java
@@ -23,7 +23,6 @@ public class CommandMessageHandler {
     public CommandMessageHandler(ClientApiBase clientApiBase, PolychatClient client) {
         this.clientApiBase = clientApiBase;
         this.client = client;
-        System.out.println("command message handler");
     }
 
     public int calculateParameters(String command) {

--- a/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/logging/DefaultLogger.java
+++ b/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/logging/DefaultLogger.java
@@ -1,0 +1,45 @@
+package club.moddedminecraft.polychat.client.clientbase.logging;
+
+public class DefaultLogger implements Logger {
+    @Override
+    public void error(String message) {
+        System.err.println(message);
+    }
+
+    @Override
+    public void error(String message, Throwable t) {
+        System.err.println(message);
+        t.printStackTrace();
+    }
+
+    @Override
+    public void warn(String message) {
+        error(message);
+    }
+
+    @Override
+    public void warn(String message, Throwable t) {
+        error(message, t);
+    }
+
+    @Override
+    public void info(String message) {
+        System.out.println(message);
+    }
+
+    @Override
+    public void info(String message, Throwable t) {
+        System.out.println(message);
+        t.printStackTrace(System.out);
+    }
+
+    @Override
+    public void debug(String message) {
+        info(message);
+    }
+
+    @Override
+    public void debug(String message, Throwable t) {
+        info(message, t);
+    }
+}

--- a/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/logging/LogManager.java
+++ b/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/logging/LogManager.java
@@ -1,0 +1,7 @@
+package club.moddedminecraft.polychat.client.clientbase.logging;
+
+public class LogManager {
+    public static Logger LOGGER = new DefaultLogger();
+
+    private LogManager() {}
+}

--- a/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/logging/Logger.java
+++ b/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/logging/Logger.java
@@ -1,0 +1,12 @@
+package club.moddedminecraft.polychat.client.clientbase.logging;
+
+public interface Logger {
+    void error(String message);
+    void error(String message, Throwable t);
+    void warn(String message);
+    void warn(String message, Throwable t);
+    void info(String message);
+    void info(String message, Throwable t);
+    void debug(String message);
+    void debug(String message, Throwable t);
+}

--- a/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/util/MuteStorage.java
+++ b/client/client-base/src/main/java/club/moddedminecraft/polychat/client/clientbase/util/MuteStorage.java
@@ -1,5 +1,7 @@
 package club.moddedminecraft.polychat.client.clientbase.util;
 
+import club.moddedminecraft.polychat.client.clientbase.logging.LogManager;
+
 import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
@@ -19,14 +21,14 @@ public class MuteStorage {
         try {
             Object unparsed = new ObjectInputStream(new FileInputStream(path.resolve(FILENAME).toFile())).readObject();
             if (!(unparsed instanceof UUID[])) {
-                System.err.println("Failed to parse mutelist!");
+                LogManager.LOGGER.warn("Failed to parse mutelist!");
                 return;
             }
             UUID[] uuids = (UUID[]) unparsed;
             List<UUID> tempList = Arrays.asList(uuids);
             Collections.addAll(muteList, uuids);
         } catch (IOException | ClassNotFoundException e) {
-            System.err.println("Failed to access mutelist!");
+            LogManager.LOGGER.warn("Failed to access mutelist!");
         }
     }
 
@@ -54,7 +56,7 @@ public class MuteStorage {
             UUID[] uuidArray = uuids.toArray(new UUID[0]);
             outputStream.writeObject(uuidArray);
         } catch (IOException e) {
-            System.err.println("Failed to access mutelist");
+            LogManager.LOGGER.warn("Failed to access mutelist");
         }
     }
 


### PR DESCRIPTION
I was working on a Polychat client implementation for a custom Minecraft proxy.

While doing this I noticed some limitations in the Polychat client base I couldn't properly work around, so instead of hacking my way around them, I decided to make a PR!

These two limitations are addressed in this PR:

## Config handling

Polychat requires a dedicated config file for each client and is incapable of getting config values passed during instantiation.

While this works fine in the scenario of a standalone Minecraft client, my client spawns multiple Polychat clients with similar configs. It is more reasonable for my usecase to maintain the configs on the implementation side and have them passed to the Polychat instance.

Which is what I did. I added an optional parameter `YamlConfig config` to the constructor of the `PolychatClient` class.


## Logging

Polychat has `System.out` / `System.err` hard-coded for logging. While this is easy and doesn't introduce a dependency on a logging library such as Log4J, I want to have the possibility of configuring my own logger.

Therefore I added an Interface `Logger` that handles all logging methods. It's implemented by a `DefaultLogger` that uses `System.out` / `System.err` like before, but gives me the possibility of adding my own logger on my implementation.


## Thread-safe sending queue

The message sending queue inside the Network Library wasn't thread-safe. If one thread received messages and another thread was sending messages, the queue could error because it used the non thread-safe ArrayDeque class. This PR replaces it with the ConcurrentLinkedDeque.